### PR TITLE
[PR] 修复 composer update 无法正确安装 2.0 版本的问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,16 @@
     },
     "require-dev" : {
    	"phpunit/phpunit": "~4.0",
-        "squizlabs/php_codesniffer": "~2.3",
+    "squizlabs/php_codesniffer": "~2.3",
 	"phpdocumentor/phpdocumentor" : "2.*"
     },
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {"OSS\\": "src/OSS"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
本 PR 解决设置了 ``minimum-stability`` 时，``composer update -vvv`` 无法安装指定版本的问题。

除了这个 PR 外，还有一个办法解决此问题([via](https://getcomposer.org/doc/05-repositories.md#package-2))：

```
{
  "type": "package",
  "package": {
    "name": "aliyuncs/oss-sdk-php",
    "version": "2.0.0",
    "dist": {
      "url": "https://github.com/aliyun/aliyun-oss-php-sdk/archive/master.zip",
      "type": "zip"
    },
    "autoload": {
      "psr-4": {"OSS\\": "src/OSS"}
    }
  }
}
```

然后在 require 中添加

```
"aliyun/oss-sdk-php": "2.0.*"
```

完成后 ``composer update`` 即可。