### PR TITLE
Refine OssException

### DIFF
--- a/src/OSS/Core/OssException.php
+++ b/src/OSS/Core/OssException.php
@@ -12,5 +12,43 @@ namespace OSS\Core;
  */
 class OssException extends \Exception
 {
+    private $details = array();
 
+    function __construct($details)
+    {
+        if (is_array($details)) {
+            $message = $details['code'] . ': ' . $details['message']
+                     . ' RequestId: ' . $details['request-id'];
+            parent::__construct($message);
+            $this->details = $details;
+        } else {
+            $message = $details;
+            parent::__construct($message);
+        }
+    }
+
+    public function getHTTPStatus()
+    {
+        return isset($this->details['status']) ? $this->details['status'] : '';
+    }
+
+    public function getRequestId()
+    {
+        return isset($this->details['request-id']) ? $this->details['request-id'] : '';
+    }
+
+    public function getErrorCode()
+    {
+        return isset($this->details['code']) ? $this->details['code'] : '';
+    }
+
+    public function getErrorMessage()
+    {
+        return isset($this->details['message']) ? $this->details['message'] : '';
+    }
+
+    public function getDetails()
+    {
+        return isset($this->details['body']) ? $this->details['body'] : '';
+    }
 }

--- a/src/OSS/Result/Result.php
+++ b/src/OSS/Result/Result.php
@@ -81,23 +81,20 @@ abstract class Result
         if ($this->isOk) {
             $this->parsedData = $this->parseDataFromResponse();
         } else {
+            $httpStatus = strval($this->rawResponse->status);
             $requestId = strval($this->getRequestId());
             $code = $this->retrieveErrorCode($this->rawResponse->body);
             $message = $this->retrieveErrorMessage($this->rawResponse->body);
+            $body = $this->rawResponse->body;
 
-            $this->errorMessage = "http status: " . strval($this->rawResponse->status);
-            if (!empty($requestId)) {
-                $this->errorMessage .= ", requestId: " . strval($this->getRequestId());
-            }
-            if (!empty($code) && !empty($message)) {
-                $this->errorMessage .= ", Code: " . $code;
-                $this->errorMessage .= ", Message: " . $message;
-            } else {
-                if (intval($this->rawResponse->status) === 403) {
-                    $this->errorMessage .= ", Reason: " . "authorization forbidden, please check your AccessKeyId and AccessKeySecret";
-                }
-            }
-            throw new OssException($this->errorMessage);
+            $details = array(
+                'status' => $httpStatus,
+                'request-id' => $requestId,
+                'code' => $code,
+                'message' => $message,
+                'body' => $body
+            );
+            throw new OssException($details);
         }
     }
 
@@ -169,10 +166,6 @@ abstract class Result
      * 由子类解析过的数据
      */
     protected $parsedData = null;
-    /**
-     * 错误提示，如果isOk非真，这个变量存放问题原因
-     */
-    protected $errorMessage = null;
     /**
      * 存放auth函数返回的原始Response
      *

--- a/tests/OSS/Tests/HttpTest.php
+++ b/tests/OSS/Tests/HttpTest.php
@@ -40,8 +40,11 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     public function testSendMultiRequest()
     {
         $httpCore = new RequestCore("http://www.baidu.com");
-        @$result = $httpCore->send_multi_request(array(curl_init("http://www.baidu.com"),
-            curl_init("http://www.baidu.com")));
+        $ch1 = curl_init("http://www.baidu.com");
+        curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
+        $ch2 = curl_init("http://cn.bing.com");
+        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, 1);
+        @$result = $httpCore->send_multi_request(array($ch1, $ch2));
         $this->assertNotNull($result);
     }
 
@@ -72,7 +75,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             $httpCore = new RequestCore("http://www.notexistsitexx.com");
             $httpCore->set_body("");
             $httpCore->set_method("GET");
-//            $httpCore->set_proxy();
             $httpCore->connect_timeout = 10;
             $httpCore->timeout = 10;
             $res = $httpCore->send_request();

--- a/tests/OSS/Tests/OssClientBucketTest.php
+++ b/tests/OSS/Tests/OssClientBucketTest.php
@@ -49,7 +49,8 @@ class OssClientBucketTest extends TestOssClientBase
         try {
             $this->ossClient->deleteBucket($this->bucket);
         } catch (OssException $e) {
-            $this->assertTrue(OssUtil::startsWith($e->getMessage(), "http status: 409"));
+            $this->assertEquals("BucketNotEmpty", $e->getErrorCode());
+            $this->assertEquals("409", $e->getHTTPStatus());
         }
 
 

--- a/tests/OSS/Tests/OssClientSignatureTest.php
+++ b/tests/OSS/Tests/OssClientSignatureTest.php
@@ -19,7 +19,6 @@ class OssClientSignatureTest extends TestOssClientBase
         $timeout = 3600;
         try {
             $signedUrl = $this->ossClient->signUrl($this->bucket, $object, $timeout);
-            var_dump($signedUrl);
         } catch (OssException $e) {
             $this->assertFalse(true);
         }


### PR DESCRIPTION
Make detailed error information accessable. Use it like this:

    try {
        $ossClient->getBucketAcl('hello');
    } catch (OssException $e) {
        print($e->getMessage() . "\n");
        print("Details: " . $e->getDetails() . "\n");
        print("HTTP Code: " . $e->getHTTPStatus() . "\n");
        print("RequestId: " . $e->getRequestId() . "\n");
        print("ErrorCode: " . $e->getErrorCode() . "\n");
        print("ErrorMessage: " . $e->getErrorMessage() . "\n");
    }
