### PR TITLE
Fix return null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.lock
 doc
 output
 .idea
+.buildpath
+.project
+.settings

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+
 <phpunit>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src</directory>
-    </whitelist>
-  </filter>
-  <logging>
-    <log type="coverage-clover" target="coverage.xml" />
-  </logging>
-  <testsuites>
-    <testsuite name="FunctionTest">
-      <directory>./tests</directory>
-      <exclude>./tests/OSS/Tests/BucketCnameTest.php</exclude>
-    </testsuite>
-  </testsuites>
+	<filter>
+		<whitelist>
+			<directory suffix=".php">./src</directory>
+		</whitelist>
+	</filter>
+	<logging>
+		<log type="coverage-clover" target="coverage.xml" />
+	</logging>
+	<testsuites>
+		<testsuite name="FunctionTest">
+			<directory>./tests</directory>
+			<exclude>./tests/OSS/Tests/BucketCnameTest.php</exclude>
+		</testsuite>
+	</testsuites>
 </phpunit>

--- a/samples/Callback.php
+++ b/samples/Callback.php
@@ -1,0 +1,82 @@
+<?php
+require_once __DIR__ . '/Common.php';
+
+use OSS\OssClient;
+use OSS\Core\OssException;
+
+$bucket = Common::getBucketName();
+$ossClient = Common::getOssClient();
+if (is_null($ossClient)) exit(1);
+//*******************************简单使用***************************************************************
+
+// putobject 使用callback上传内容到oss文件
+// callbackurl参数指定请求回调的服务器url
+// callbackbodytype参数可为application/json或application/x-www-form-urlencoded
+// OSS_CALLBACK_VAR参数可以不设置
+
+$json = 
+    '{
+        "callbackUrl":"callback.oss-demo.com:23450",
+        "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+        "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+        "callbackBodyType":"application/json"
+    }';
+$var = 
+    '{
+        "x:var1":"value1",
+        "x:var2":"值2"
+    }';
+$options = array(OssClient::OSS_CALLBACK => $json,
+                 OssClient::OSS_CALLBACK_VAR => $var
+                );
+$result = $ossClient->putObject($bucket, "b.file", "random content", $options);
+Common::println($result['body']);
+Common::println($result['_info']['http_code']);
+// completeMultipartUpload 使用callback上传内容到oss文件
+// callbackurl参数指定请求回调的服务器url
+// callbackbodytype参数可为application/json或application/x-www-form-urlencoded
+// OSS_CALLBACK_VAR参数可以不设置
+
+$object = "multipart-callback-test.txt";
+$copiedObject = "multipart-callback-test.txt.copied";
+$ossClient->putObject($bucket, $copiedObject, file_get_contents(__FILE__));
+
+/**
+  *  step 1. 初始化一个分块上传事件, 也就是初始化上传Multipart, 获取upload id
+  */
+$upload_id = $ossClient->initiateMultipartUpload($bucket, $object);
+/*
+ * step 2. uploadPartCopy
+ */
+$copyId = 1;
+$eTag = $ossClient->uploadPartCopy($bucket, $copiedObject, $bucket, $object, $copyId, $upload_id);
+$upload_parts[] = array(
+    'PartNumber' => $copyId,
+    'ETag' => $eTag,
+    );
+$listPartsInfo = $ossClient->listParts($bucket, $object, $upload_id);
+
+/**
+  * step 3.
+  */
+        
+$json = 
+    '{
+        "callbackUrl":"callback.oss-demo.com:23450",
+        "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+        "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+        "callbackBodyType":"application/json"
+    }';
+            
+$var = 
+    '{
+        "x:var1":"value1",
+        "x:var2":"值2"
+    }';
+$options = array(OssClient::OSS_CALLBACK => $json,
+                 OssClient::OSS_CALLBACK_VAR => $var);
+
+$result = $ossClient->completeMultipartUpload($bucket, $object, $upload_id, $upload_parts, $options);
+Common::println($result['body']);
+Common::println($result['_info']['http_code']);
+

--- a/samples/Callback.php
+++ b/samples/Callback.php
@@ -2,11 +2,11 @@
 require_once __DIR__ . '/Common.php';
 
 use OSS\OssClient;
-use OSS\Core\OssException;
 
 $bucket = Common::getBucketName();
 $ossClient = Common::getOssClient();
 if (is_null($ossClient)) exit(1);
+
 //*******************************简单使用***************************************************************
 
 /** putObject 使用callback上传内容到oss文件
@@ -33,6 +33,7 @@ $options = array(OssClient::OSS_CALLBACK => $url,
 $result = $ossClient->putObject($bucket, "b.file", "random content", $options);
 Common::println($result['body']);
 Common::println($result['info']['http_code']);
+
 /**
   * completeMultipartUpload 使用callback上传内容到oss文件
   * callbackurl参数指定请求回调的服务器url
@@ -42,11 +43,13 @@ Common::println($result['info']['http_code']);
 $object = "multipart-callback-test.txt";
 $copiedObject = "multipart-callback-test.txt.copied";
 $ossClient->putObject($bucket, $copiedObject, file_get_contents(__FILE__));
+
 /**
   *  step 1. 初始化一个分块上传事件, 也就是初始化上传Multipart, 获取upload id
   */
 $upload_id = $ossClient->initiateMultipartUpload($bucket, $object);
-/*
+
+/**
  * step 2. uploadPartCopy
  */
 $copyId = 1;
@@ -56,9 +59,10 @@ $upload_parts[] = array(
     'ETag' => $eTag,
     );
 $listPartsInfo = $ossClient->listParts($bucket, $object, $upload_id);
+
 /**
-  * step 3.
-  */
+ * step 3.
+ */
 $json = 
     '{
         "callbackUrl":"callback.oss-demo.com:23450",
@@ -66,7 +70,6 @@ $json =
         "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size},\"x:var1\":${x:var1},\"x:var2\":${x:var2}}",
         "callbackBodyType":"application/json"
     }';
-            
 $var = 
     '{
         "x:var1":"value1",
@@ -78,4 +81,3 @@ $options = array(OssClient::OSS_CALLBACK => $json,
 $result = $ossClient->completeMultipartUpload($bucket, $object, $upload_id, $upload_parts, $options);
 Common::println($result['body']);
 Common::println($result['info']['http_code']);
-

--- a/samples/Callback.php
+++ b/samples/Callback.php
@@ -9,38 +9,39 @@ $ossClient = Common::getOssClient();
 if (is_null($ossClient)) exit(1);
 //*******************************简单使用***************************************************************
 
-// putobject 使用callback上传内容到oss文件
-// callbackurl参数指定请求回调的服务器url
-// callbackbodytype参数可为application/json或application/x-www-form-urlencoded
-// OSS_CALLBACK_VAR参数可以不设置
-
-$json = 
+/** putObject 使用callback上传内容到oss文件
+  * callbackurl参数指定请求回调的服务器url
+  * callbackbodytype参数可为application/json或application/x-www-form-urlencoded, 可选参数，默认为application/x-www-form-urlencoded
+  * OSS_CALLBACK_VAR参数可以不设置
+  */
+$url = 
     '{
         "callbackUrl":"callback.oss-demo.com:23450",
         "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-        "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
-        "callbackBodyType":"application/json"
+        "callbackBody":"bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&imageInfo.height=${imageInfo.height}&imageInfo.width=${imageInfo.width}&imageInfo.format=${imageInfo.format}&my_var1=${x:var1}&my_var2=${x:var2}",
+         "callbackBodyType":"application/x-www-form-urlencoded"
+
     }';
 $var = 
     '{
         "x:var1":"value1",
         "x:var2":"值2"
     }';
-$options = array(OssClient::OSS_CALLBACK => $json,
+$options = array(OssClient::OSS_CALLBACK => $url,
                  OssClient::OSS_CALLBACK_VAR => $var
                 );
 $result = $ossClient->putObject($bucket, "b.file", "random content", $options);
 Common::println($result['body']);
-Common::println($result['_info']['http_code']);
-// completeMultipartUpload 使用callback上传内容到oss文件
-// callbackurl参数指定请求回调的服务器url
-// callbackbodytype参数可为application/json或application/x-www-form-urlencoded
-// OSS_CALLBACK_VAR参数可以不设置
-
+Common::println($result['info']['http_code']);
+/**
+  * completeMultipartUpload 使用callback上传内容到oss文件
+  * callbackurl参数指定请求回调的服务器url
+  * callbackbodytype参数可为application/json或application/x-www-form-urlencoded, 可选参数，默认为application/x-www-form-urlencoded
+  * OSS_CALLBACK_VAR参数可以不设置
+  */  
 $object = "multipart-callback-test.txt";
 $copiedObject = "multipart-callback-test.txt.copied";
 $ossClient->putObject($bucket, $copiedObject, file_get_contents(__FILE__));
-
 /**
   *  step 1. 初始化一个分块上传事件, 也就是初始化上传Multipart, 获取upload id
   */
@@ -55,16 +56,14 @@ $upload_parts[] = array(
     'ETag' => $eTag,
     );
 $listPartsInfo = $ossClient->listParts($bucket, $object, $upload_id);
-
 /**
   * step 3.
   */
-        
 $json = 
     '{
         "callbackUrl":"callback.oss-demo.com:23450",
         "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-        "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+        "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size},\"x:var1\":${x:var1},\"x:var2\":${x:var2}}",
         "callbackBodyType":"application/json"
     }';
             
@@ -78,5 +77,5 @@ $options = array(OssClient::OSS_CALLBACK => $json,
 
 $result = $ossClient->completeMultipartUpload($bucket, $object, $upload_id, $upload_parts, $options);
 Common::println($result['body']);
-Common::println($result['_info']['http_code']);
+Common::println($result['info']['http_code']);
 

--- a/samples/Image.php
+++ b/samples/Image.php
@@ -2,14 +2,15 @@
 require_once __DIR__ . '/Common.php';
 
 use OSS\OssClient;
-use OSS\Core\OssException;
 
 $bucketName = Common::getBucketName();
 $object = "example.jpg";
 $ossClient = Common::getOssClient();
 $download_file = "download.jpg";
 if (is_null($ossClient)) exit(1);
+
 //*******************************简单使用***************************************************************
+
 // 先把本地的example.jpg上传到指定$bucket, 命名为$object
 $ossClient->uploadFile($bucketName, $object, "example.jpg");
 
@@ -64,7 +65,7 @@ printImage("imageInfo", $download_file);
 
 
 /**
-    生成一个带签名的可用于浏览器直接打开的url, URL的有效期是3600秒
+ *  生成一个带签名的可用于浏览器直接打开的url, URL的有效期是3600秒
  */
  $timeout = 3600;
 $options = array(

--- a/samples/LiveChannel.php
+++ b/samples/LiveChannel.php
@@ -2,7 +2,6 @@
 require_once __DIR__ . '/Common.php';
 
 use OSS\OssClient;
-use OSS\Core\OssException;
 use OSS\Model\LiveChannelConfig;
 
 $bucket = Common::getBucketName();
@@ -65,7 +64,7 @@ $resp = $ossClient->putLiveChannelStatus($bucket, "test_rtmp_live", "enabled");
 
 /**
     创建好直播频道之后调用getLiveChannelInfo可以得到频道相关的信息
-*/
+ */
 $info = $ossClient->getLiveChannelInfo($bucket, 'test_rtmp_live');
 Common::println("bucket $bucket LiveChannelInfo:\n" . 
 "live channel info description: ". $info->getDescription() . "\n" .
@@ -109,9 +108,9 @@ Common::println("bucket $bucket listLiveChannel:\n" .
 "live channel status AdioCodec: ". $status->getAudioCodec() . "\n");
 
 /**
-    如果希望利用直播推流产生的ts文件生成一个点播列表，可以使用postVodPlaylist方法。
-    指定起始时间为当前时间减去60秒，结束时间为当前时间，这意味着将生成一个长度为60秒的点播视频。
-    播放列表指定为“vod_playlist.m3u8”，也就是说这个接口调用成功之后会在OSS上生成一个名叫“vod_playlist.m3u8”的播放列表文件。
+ *  如果希望利用直播推流产生的ts文件生成一个点播列表，可以使用postVodPlaylist方法。
+ *  指定起始时间为当前时间减去60秒，结束时间为当前时间，这意味着将生成一个长度为60秒的点播视频。
+ *  播放列表指定为“vod_playlist.m3u8”，也就是说这个接口调用成功之后会在OSS上生成一个名叫“vod_playlist.m3u8”的播放列表文件。
  */
 $current_time = time();
 $ossClient->postVodPlaylist($bucket,
@@ -121,6 +120,6 @@ $ossClient->postVodPlaylist($bucket,
 );
 
 /**
-    如果一个直播频道已经不打算再使用了，那么可以调用delete_live_channel来删除频道。
+ *  如果一个直播频道已经不打算再使用了，那么可以调用delete_live_channel来删除频道。
  */
 $ossClient->deleteBucketLiveChannel($bucket, "test_rtmp_live");

--- a/samples/Object.php
+++ b/samples/Object.php
@@ -61,7 +61,7 @@ Common::println("file c.file.copy exist? " . ($doesExist ? "yes" : "no"));
 // 批量删除object
 $result = $ossClient->deleteObjects($bucket, array("b.file", "c.file"));
 foreach($result as $object)
-    print($object);
+    Common::println($object);
 
 sleep(2);
 unlink("c.file.localcopy");

--- a/samples/Object.php
+++ b/samples/Object.php
@@ -9,13 +9,33 @@ $ossClient = Common::getOssClient();
 if (is_null($ossClient)) exit(1);
 //*******************************简单使用***************************************************************
 
-// 简单上传变量的内容到文件
+// 简单上传变量的内容到oss文件
 $result = $ossClient->putObject($bucket, "b.file", "hi, oss");
 Common::println("b.file is created");
 Common::println($result['x-oss-request-id']);
 Common::println($result['etag']);
 Common::println($result['content-md5']);
 Common::println($result['body']);
+
+// 使用callback上传内容到oss文件
+// callbackUrl参数指定请求回调的服务器URL
+// callbackBodyType参数可为application/json或application/x-www-form-urlencoded
+$json = 
+'{
+"callbackUrl":"callback.oss-demo.com:23450",
+"callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+"callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+"callbackBodyType":"application/json"
+}';
+$var = 
+'{
+"x:var1":"value1",
+"x:var2":"值2"
+}';
+$options = array(OssClient::OSS_CALLBACK => $json,
+                 OssClient::OSS_CALLBACK_VAR => $var
+                );
+$result = $ossClient->putObject($bucket, "b.file", "random content", $options);
 
 // 上传本地文件
 $result = $ossClient->uploadFile($bucket, "c.file", __FILE__);

--- a/samples/Object.php
+++ b/samples/Object.php
@@ -10,12 +10,21 @@ if (is_null($ossClient)) exit(1);
 //*******************************简单使用***************************************************************
 
 // 简单上传变量的内容到文件
-$ossClient->putObject($bucket, "b.file", "hi, oss");
+$result = $ossClient->putObject($bucket, "b.file", "hi, oss");
 Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 // 上传本地文件
-$ossClient->uploadFile($bucket, "c.file", __FILE__);
+$result = $ossClient->uploadFile($bucket, "c.file", __FILE__);
 Common::println("c.file is created");
+Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 // 下载object到本地变量
 $content = $ossClient->getObject($bucket, "b.file");
@@ -26,28 +35,48 @@ Common::println("b.file is fetched, the content is: " . $content);
 $options = array(
     OssClient::OSS_FILE_DOWNLOAD => "./c.file.localcopy",
 );
-$ossClient->getObject($bucket, "c.file", $options);
+$result = $ossClient->getObject($bucket, "c.file", $options);
 Common::println("b.file is fetched to the local file: c.file.localcopy");
+Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 // 拷贝object
-$ossClient->copyObject($bucket, "c.file", $bucket, "c.file.copy");
+$result = $ossClient->copyObject($bucket, "c.file", $bucket, "c.file.copy");
 Common::println("c.file is copied to c.file.copy");
+Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 // 判断object是否存在
 $doesExist = $ossClient->doesObjectExist($bucket, "c.file.copy");
 Common::println("file c.file.copy exist? " . ($doesExist ? "yes" : "no"));
 
 // 删除object
-$ossClient->deleteObject($bucket, "c.file.copy");
+$result = $ossClient->deleteObject($bucket, "c.file.copy");
 Common::println("c.file.copy is deleted");
+Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 // 判断object是否存在
 $doesExist = $ossClient->doesObjectExist($bucket, "c.file.copy");
 Common::println("file c.file.copy exist? " . ($doesExist ? "yes" : "no"));
 
 // 批量删除object
-$ossClient->deleteObjects($bucket, array("b.file", "c.file"));
+$result = $ossClient->deleteObjects($bucket, array("b.file", "c.file"));
 Common::println("b.file, c.file are deleted");
+Common::println("b.file is created");
+Common::println($result['x-oss-request-id']);
+Common::println($result['etag']);
+Common::println($result['content-md5']);
+Common::println($result['body']);
 
 sleep(2);
 unlink("c.file.localcopy");

--- a/samples/Object.php
+++ b/samples/Object.php
@@ -38,19 +38,11 @@ $options = array(
 $result = $ossClient->getObject($bucket, "c.file", $options);
 Common::println("b.file is fetched to the local file: c.file.localcopy");
 Common::println("b.file is created");
-Common::println($result['x-oss-request-id']);
-Common::println($result['etag']);
-Common::println($result['content-md5']);
-Common::println($result['body']);
 
 // 拷贝object
 $result = $ossClient->copyObject($bucket, "c.file", $bucket, "c.file.copy");
-Common::println("c.file is copied to c.file.copy");
-Common::println("b.file is created");
-Common::println($result['x-oss-request-id']);
-Common::println($result['etag']);
-Common::println($result['content-md5']);
-Common::println($result['body']);
+foreach($result as $val)
+    print($val);
 
 // 判断object是否存在
 $doesExist = $ossClient->doesObjectExist($bucket, "c.file.copy");
@@ -61,9 +53,6 @@ $result = $ossClient->deleteObject($bucket, "c.file.copy");
 Common::println("c.file.copy is deleted");
 Common::println("b.file is created");
 Common::println($result['x-oss-request-id']);
-Common::println($result['etag']);
-Common::println($result['content-md5']);
-Common::println($result['body']);
 
 // 判断object是否存在
 $doesExist = $ossClient->doesObjectExist($bucket, "c.file.copy");
@@ -71,12 +60,8 @@ Common::println("file c.file.copy exist? " . ($doesExist ? "yes" : "no"));
 
 // 批量删除object
 $result = $ossClient->deleteObjects($bucket, array("b.file", "c.file"));
-Common::println("b.file, c.file are deleted");
-Common::println("b.file is created");
-Common::println($result['x-oss-request-id']);
-Common::println($result['etag']);
-Common::println($result['content-md5']);
-Common::println($result['body']);
+foreach($result as $object)
+    print($object);
 
 sleep(2);
 unlink("c.file.localcopy");

--- a/samples/Object.php
+++ b/samples/Object.php
@@ -17,26 +17,6 @@ Common::println($result['etag']);
 Common::println($result['content-md5']);
 Common::println($result['body']);
 
-// 使用callback上传内容到oss文件
-// callbackUrl参数指定请求回调的服务器URL
-// callbackBodyType参数可为application/json或application/x-www-form-urlencoded
-$json = 
-'{
-"callbackUrl":"callback.oss-demo.com:23450",
-"callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-"callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
-"callbackBodyType":"application/json"
-}';
-$var = 
-'{
-"x:var1":"value1",
-"x:var2":"值2"
-}';
-$options = array(OssClient::OSS_CALLBACK => $json,
-                 OssClient::OSS_CALLBACK_VAR => $var
-                );
-$result = $ossClient->putObject($bucket, "b.file", "random content", $options);
-
 // 上传本地文件
 $result = $ossClient->uploadFile($bucket, "c.file", __FILE__);
 Common::println("c.file is created");
@@ -55,14 +35,14 @@ Common::println("b.file is fetched, the content is: " . $content);
 $options = array(
     OssClient::OSS_FILE_DOWNLOAD => "./c.file.localcopy",
 );
-$result = $ossClient->getObject($bucket, "c.file", $options);
+$ossClient->getObject($bucket, "c.file", $options);
 Common::println("b.file is fetched to the local file: c.file.localcopy");
 Common::println("b.file is created");
 
 // 拷贝object
 $result = $ossClient->copyObject($bucket, "c.file", $bucket, "c.file.copy");
-foreach($result as $val)
-    print($val);
+Common::println("lastModifiedTime: " . $result[0]);
+Common::println("ETag: " . $result[1]);
 
 // 判断object是否存在
 $doesExist = $ossClient->doesObjectExist($bucket, "c.file.copy");

--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -775,8 +775,8 @@ class RequestCore
 
             // Reset the headers to the appropriate property.
             $this->response_headers = $header_assoc;
-            $this->response_headers['_info'] = $this->response_info;
-            $this->response_headers['_info']['method'] = $this->method;
+            $this->response_headers['info'] = $this->response_info;
+            $this->response_headers['info']['method'] = $this->method;
 
             if ($curl_handle && $response) {
                 //return new $this->response_class($this->response_headers, $this->response_body, $this->response_code, $this->curl_handle);

--- a/src/OSS/Model/LiveChannelConfig.php
+++ b/src/OSS/Model/LiveChannelConfig.php
@@ -3,8 +3,6 @@
 namespace OSS\Model;
 
 
-use OSS\Core\OssException;
-
 /**
  * Class LiveChannelConfig
  * @package OSS\Model

--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -28,6 +28,8 @@ use OSS\Model\ListMultipartUploadInfo;
 use OSS\Result\ListObjectsResult;
 use OSS\Result\ListPartsResult;
 use OSS\Result\PutSetDeleteResult;
+use OSS\Result\DeleteObjectsResult;
+use OSS\Result\CopyObjectResult;
 use OSS\Result\ExistResult;
 use OSS\Result\PutLiveChannelResult;
 use OSS\Result\GetLiveChannelHistoryResult;
@@ -1131,7 +1133,7 @@ class OssClient
             $options[self::OSS_HEADERS] = array(self::OSS_OBJECT_COPY_SOURCE => '/' . $fromBucket . '/' . $fromObject);
         }
         $response = $this->auth($options);
-        $result = new PutSetDeleteResult($response);
+        $result = new CopyObjectResult($response);
         return $result->getData();
     }
 
@@ -1204,7 +1206,7 @@ class OssClient
         $xmlBody = OssUtil::createDeleteObjectsXmlBody($objects, $quiet);
         $options[self::OSS_CONTENT] = $xmlBody;
         $response = $this->auth($options);
-        $result = new PutSetDeleteResult($response);
+        $result = new DeleteObjectsResult($response);
         return $result->getData();
     }
 

--- a/src/OSS/Result/AclResult.php
+++ b/src/OSS/Result/AclResult.php
@@ -3,7 +3,6 @@
 namespace OSS\Result;
 
 use OSS\Core\OssException;
-use OSS\Tests\OssExceptionTest;
 
 /**
  * Class AclResult getBucketAcl接口返回结果类，封装了

--- a/src/OSS/Result/CallbackResult.php
+++ b/src/OSS/Result/CallbackResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OSS\Result;
+
+
+/**
+ * Class CallbackResult
+ * @package OSS\Result
+ */
+class CallbackResult extends PutSetDeleteResult
+{
+    protected function isResponseOk()
+    {
+        $status = $this->rawResponse->status;
+        if ((int)(intval($status) / 100) == 2 && (int)(intval($status) != 203)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/OSS/Result/CallbackResult.php
+++ b/src/OSS/Result/CallbackResult.php
@@ -12,7 +12,7 @@ class CallbackResult extends PutSetDeleteResult
     protected function isResponseOk()
     {
         $status = $this->rawResponse->status;
-        if ((int)(intval($status) / 100) == 2 && (int)(intval($status) !== 203)) {
+        if ((int)(intval($status) / 100) == 2 && (int)(intval($status)) !== 203) {
             return true;
         }
         return false;

--- a/src/OSS/Result/CallbackResult.php
+++ b/src/OSS/Result/CallbackResult.php
@@ -12,7 +12,7 @@ class CallbackResult extends PutSetDeleteResult
     protected function isResponseOk()
     {
         $status = $this->rawResponse->status;
-        if ((int)(intval($status) / 100) == 2 && (int)(intval($status) != 203)) {
+        if ((int)(intval($status) / 100) == 2 && (int)(intval($status) !== 203)) {
             return true;
         }
         return false;

--- a/src/OSS/Result/CopyObjectResult.php
+++ b/src/OSS/Result/CopyObjectResult.php
@@ -15,10 +15,6 @@ class CopyObjectResult extends Result
     protected function parseDataFromResponse()
     {
         $body = $this->rawResponse->body;
-        if (empty($body) || false === strpos($body, '<?xml')) {
-            return '';
-        }
-
         $xml = simplexml_load_string($body); 
         $result = array();
         

--- a/src/OSS/Result/CopyObjectResult.php
+++ b/src/OSS/Result/CopyObjectResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OSS\Result;
+
+
+/**
+ * Class CopyObjectResult
+ * @package OSS\Result
+ */
+class CopyObjectResult extends Result
+{
+    /**
+     * @return array()
+     */
+    protected function parseDataFromResponse()
+    {
+        $body = $this->rawResponse->body;
+        if (empty($body) || false === strpos($body, '<?xml')) {
+            return '';
+        }
+
+        $xml = simplexml_load_string($body); 
+        $result = array();
+        
+        if (isset($xml->LastModified)) {
+            $result[] = $xml->LastModified;
+        }
+        if (isset($xml->ETag)) {
+            $result[] = $xml->ETag;
+        }
+
+         return $result;
+    }
+}

--- a/src/OSS/Result/DeleteObjectsResult.php
+++ b/src/OSS/Result/DeleteObjectsResult.php
@@ -15,10 +15,6 @@ class DeleteObjectsResult extends Result
     protected function parseDataFromResponse()
     {
         $body = $this->rawResponse->body;
-        if (empty($body) || false === strpos($body, '<?xml')) {
-            return '';
-        }
-
         $xml = simplexml_load_string($body); 
         $objects = array();
 

--- a/src/OSS/Result/DeleteObjectsResult.php
+++ b/src/OSS/Result/DeleteObjectsResult.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OSS\Result;
+
+
+/**
+ * Class DeleteObjectsResult
+ * @package OSS\Result
+ */
+class DeleteObjectsResult extends Result
+{
+    /**
+     * @return array()
+     */
+    protected function parseDataFromResponse()
+    {
+        $body = $this->rawResponse->body;
+        if (empty($body) || false === strpos($body, '<?xml')) {
+            return '';
+        }
+
+        $xml = simplexml_load_string($body); 
+        $objects = array();
+
+        if (isset($xml->Deleted)) {
+            foreach($xml->Deleted as $deleteKey)
+                $objects[] = $deleteKey->Key;
+        }
+        return $objects;
+    }
+}

--- a/src/OSS/Result/PutSetDeleteResult.php
+++ b/src/OSS/Result/PutSetDeleteResult.php
@@ -10,10 +10,11 @@ namespace OSS\Result;
 class PutSetDeleteResult extends Result
 {
     /**
-     * @return null
+     * @return array()
      */
     protected function parseDataFromResponse()
     {
-        return null;
+        $body = array('body' => $this->rawResponse->body);
+        return array_merge($this->rawResponse->header, $body);
     }
 }

--- a/tests/OSS/Tests/BucketCnameTest.php
+++ b/tests/OSS/Tests/BucketCnameTest.php
@@ -4,9 +4,7 @@ namespace OSS\Tests;
 
 require_once __DIR__ . '/Common.php';
 
-use OSS\OssClient;
 use OSS\Model\CnameConfig;
-use OSS\Core\OssException;
 
 class BucketCnameTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OSS/Tests/BucketLiveChannelTest.php
+++ b/tests/OSS/Tests/BucketLiveChannelTest.php
@@ -4,10 +4,7 @@ namespace OSS\Tests;
 
 require_once __DIR__ . '/Common.php';
 
-use OSS\OssClient;
 use OSS\Model\LiveChannelConfig;
-use OSS\Model\LiveChannelInfo;
-use OSS\Model\LiveChannelListInfo;
 use OSS\Core\OssException;
 
 class BucketLiveChannelTest extends \PHPUnit_Framework_TestCase

--- a/tests/OSS/Tests/CallbackTest.php
+++ b/tests/OSS/Tests/CallbackTest.php
@@ -47,25 +47,27 @@ class CallbackTest extends TestOssClientBase
         
         $json = 
         '{
-            "callbackUrl":"www.baidu.com",
+            "callbackUrl":"callback.oss-demo.com:23450",
             "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-            "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
             "callbackBodyType":"application/json"
         }';
             
        $var = 
        '{
-       "x:var1":"value1",
-       "x:var2":"值2"
+           "x:var1":"value1",
+           "x:var2":"值2"
        }';
        $options = array(OssClient::OSS_CALLBACK => $json,
                         OssClient::OSS_CALLBACK_VAR => $var
                        );
-        
+
         try {
             $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
+            $this->assertEquals("200", $result['_info']['http_code']);
+            $this->assertEquals("{\"Status\":\"OK\"}", $result['body']);
         } catch (OssException $e) {
-            $this->assertTrue(true);
+            $this->assertTrue(false);
         }
     }
 
@@ -106,9 +108,9 @@ class CallbackTest extends TestOssClientBase
         
         $json = 
         '{
-            "callbackUrl":"callback.oss-demo.com:23450",
+            "callbackUrl":"www.baidu.com",
             "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-            "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
             "callbackBodyType":"application/json"
         }';
             
@@ -123,10 +125,10 @@ class CallbackTest extends TestOssClientBase
         
         try {
             $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
-            $this->assertEquals("200", $result['_info']['http_code']);
         } catch (OssException $e) {
-            $this->assertTrue(false);
+            $this->assertTrue(true);
         }
+
     }
    
     public function testPutObjectCallbackNormal()
@@ -151,6 +153,17 @@ class CallbackTest extends TestOssClientBase
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
                 "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
                 "callbackBodyType":"application/x-www-form-urlencoded"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackOk($options, "200");
+        } 
+        // Unspecified typre 
+       {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}"
             }';
             $options = array(OssClient::OSS_CALLBACK => $json);
             $this->putObjectCallbackOk($options, "200");
@@ -185,14 +198,14 @@ class CallbackTest extends TestOssClientBase
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
                 "callbackBodyType":"application/json"
             }';
             
             $var = 
             '{
                 "x:var1":"value1",
-                "x:var2":"值2"
+                "x:var2":"aliyun.com"
             }';
             $options = array(OssClient::OSS_CALLBACK => $json,
                              OssClient::OSS_CALLBACK_VAR => $var
@@ -205,7 +218,7 @@ class CallbackTest extends TestOssClientBase
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
                 "callbackBodyType":"application/x-www-form-urlencoded"
             }';
             $var = 
@@ -256,6 +269,7 @@ class CallbackTest extends TestOssClientBase
         try {
             $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
             $this->assertEquals($status, $result['_info']['http_code']);
+            $this->assertEquals("{\"Status\":\"OK\"}", $result['body']);
         } catch (OssException $e) {
             $this->assertFalse(true);
         }
@@ -267,6 +281,7 @@ class CallbackTest extends TestOssClientBase
         $content = file_get_contents(__FILE__);
         try {
             $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
+            $this->assertTrue(false);
         } catch (OssException $e) {
             $this->assertTrue(true);
         }

--- a/tests/OSS/Tests/CallbackTest.php
+++ b/tests/OSS/Tests/CallbackTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace OSS\Tests;
+
+use OSS\Core\OssException;
+use OSS\OssClient;
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'TestOssClientBase.php';
+
+
+class CallbackTest extends TestOssClientBase
+{
+    public function testMultipartUploadCallbackNormal()
+    {
+        $object = "multipart-callback-test.txt";
+        $copiedObject = "multipart-callback-test.txt.copied";
+        $this->ossClient->putObject($this->bucket, $copiedObject, file_get_contents(__FILE__));
+
+        /**
+         *  step 1. 初始化一个分块上传事件, 也就是初始化上传Multipart, 获取upload id
+         */
+        try {
+            $upload_id = $this->ossClient->initiateMultipartUpload($this->bucket, $object);
+        } catch (OssException $e) {
+            $this->assertFalse(true);
+        }
+        /*
+         * step 2. uploadPartCopy
+         */
+        $copyId = 1;
+        $eTag = $this->ossClient->uploadPartCopy($this->bucket, $copiedObject, $this->bucket, $object, $copyId, $upload_id);
+        $upload_parts[] = array(
+            'PartNumber' => $copyId,
+            'ETag' => $eTag,
+        );
+
+        try {
+            $listPartsInfo = $this->ossClient->listParts($this->bucket, $object, $upload_id);
+            $this->assertNotNull($listPartsInfo);
+        } catch (OssException $e) {
+            $this->assertTrue(false);
+        }
+
+        /**
+         * step 3.
+         */
+        
+        $json = 
+        '{
+            "callbackUrl":"www.baidu.com",
+            "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+            "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+            "callbackBodyType":"application/json"
+        }';
+            
+       $var = 
+       '{
+       "x:var1":"value1",
+       "x:var2":"值2"
+       }';
+       $options = array(OssClient::OSS_CALLBACK => $json,
+                        OssClient::OSS_CALLBACK_VAR => $var
+                       );
+        
+        try {
+            $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
+        } catch (OssException $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function testMultipartUploadCallbackFailed()
+    {
+        $object = "multipart-callback-test.txt";
+        $copiedObject = "multipart-callback-test.txt.copied";
+        $this->ossClient->putObject($this->bucket, $copiedObject, file_get_contents(__FILE__));
+
+        /**
+         *  step 1. 初始化一个分块上传事件, 也就是初始化上传Multipart, 获取upload id
+         */
+        try {
+            $upload_id = $this->ossClient->initiateMultipartUpload($this->bucket, $object);
+        } catch (OssException $e) {
+            $this->assertFalse(true);
+        }
+        /*
+         * step 2. uploadPartCopy
+         */
+        $copyId = 1;
+        $eTag = $this->ossClient->uploadPartCopy($this->bucket, $copiedObject, $this->bucket, $object, $copyId, $upload_id);
+        $upload_parts[] = array(
+            'PartNumber' => $copyId,
+            'ETag' => $eTag,
+        );
+
+        try {
+            $listPartsInfo = $this->ossClient->listParts($this->bucket, $object, $upload_id);
+            $this->assertNotNull($listPartsInfo);
+        } catch (OssException $e) {
+            $this->assertTrue(false);
+        }
+
+        /**
+         * step 3.
+         */
+        
+        $json = 
+        '{
+            "callbackUrl":"callback.oss-demo.com:23450",
+            "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+            "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+            "callbackBodyType":"application/json"
+        }';
+            
+       $var = 
+       '{
+       "x:var1":"value1",
+       "x:var2":"值2"
+       }';
+       $options = array(OssClient::OSS_CALLBACK => $json,
+                        OssClient::OSS_CALLBACK_VAR => $var
+                       );
+        
+        try {
+            $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
+            $this->assertEquals("200", $result['_info']['http_code']);
+        } catch (OssException $e) {
+            $this->assertTrue(false);
+        }
+    }
+   
+    public function testPutObjectCallbackNormal()
+    {
+        //json
+        {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBodyType":"application/json"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackOk($options, "200");
+       }
+       //url
+       {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBodyType":"application/x-www-form-urlencoded"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackOk($options, "200");
+        }
+        //json and body is chinese
+        {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBodyType":"application/json"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackOk($options, "200");
+        }
+        //url and body is chinese
+        {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBodyType":"application/x-www-form-urlencoded"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackOk($options, "200");
+        }
+        //json and add callback_var
+        {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBodyType":"application/json"
+            }';
+            
+            $var = 
+            '{
+                "x:var1":"value1",
+                "x:var2":"值2"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json,
+                             OssClient::OSS_CALLBACK_VAR => $var
+                             );
+            $this->putObjectCallbackOk($options, "200");
+        }
+        //url and add callback_var
+        {
+            $json = 
+            '{
+                "callbackUrl":"callback.oss-demo.com:23450",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBodyType":"application/x-www-form-urlencoded"
+            }';
+            $var = 
+            '{
+                "x:var1":"value1凌波不过横塘路，但目送，芳",
+                "x:var2":"值2"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json,
+                             OssClient::OSS_CALLBACK_VAR => $var
+                            );
+            $this->putObjectCallbackOk($options, "200");
+        }
+
+    }
+
+    public function testPutCallbackWithCallbackFailed()
+    { 
+        {
+            $json = 
+            '{
+                "callbackUrl":"http://www.baidu.com",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBodyType":"application/json"
+            }';
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackFailed($options, "");
+        }
+
+        {
+            $json = 
+            '{
+                "callbackUrl":"http://www.baidu.com",
+                "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBodyType":"application/x-www-form-urlencoded"
+            }';      
+            $options = array(OssClient::OSS_CALLBACK => $json);
+            $this->putObjectCallbackFailed($options, "");
+        }
+
+    }
+
+    private function putObjectCallbackOk($options, $status)
+    {
+        $object = "oss-php-sdk-callback-test.txt";
+        $content = file_get_contents(__FILE__);
+        try {
+            $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
+            $this->assertEquals($status, $result['_info']['http_code']);
+        } catch (OssException $e) {
+            $this->assertFalse(true);
+        }
+    }
+
+    private function putObjectCallbackFailed($options, $status)
+    {
+        $object = "oss-php-sdk-callback-test.txt";
+        $content = file_get_contents(__FILE__);
+        try {
+            $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
+        } catch (OssException $e) {
+            $this->assertTrue(true);
+        }
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+}

--- a/tests/OSS/Tests/CallbackTest.php
+++ b/tests/OSS/Tests/CallbackTest.php
@@ -49,7 +49,7 @@ class CallbackTest extends TestOssClientBase
         '{
             "callbackUrl":"callback.oss-demo.com:23450",
             "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size},\"x:var1\":${x:var1},\"x:var2\":${x:var2}}",
             "callbackBodyType":"application/json"
         }';
             
@@ -64,7 +64,7 @@ class CallbackTest extends TestOssClientBase
 
         try {
             $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
-            $this->assertEquals("200", $result['_info']['http_code']);
+            $this->assertEquals("200", $result['info']['http_code']);
             $this->assertEquals("{\"Status\":\"OK\"}", $result['body']);
         } catch (OssException $e) {
             $this->assertTrue(false);
@@ -110,7 +110,7 @@ class CallbackTest extends TestOssClientBase
         '{
             "callbackUrl":"www.baidu.com",
             "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+            "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size},\"x:var1\":${x:var1},\"x:var2\":${x:var2}}",
             "callbackBodyType":"application/json"
         }';
             
@@ -125,8 +125,10 @@ class CallbackTest extends TestOssClientBase
         
         try {
             $result = $this->ossClient->completeMultipartUpload($this->bucket, $object, $upload_id, $upload_parts, $options);
+            $this->assertTrue(false);
         } catch (OssException $e) {
             $this->assertTrue(true);
+            $this->assertEquals("203", $e->getHTTPStatus());
         }
 
     }
@@ -147,25 +149,25 @@ class CallbackTest extends TestOssClientBase
        }
        //url
        {
-            $json = 
+            $url = 
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBody":"bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&imageInfo.height=${imageInfo.height}&imageInfo.width=${imageInfo.width}&imageInfo.format=${imageInfo.format}",
                 "callbackBodyType":"application/x-www-form-urlencoded"
             }';
-            $options = array(OssClient::OSS_CALLBACK => $json);
+            $options = array(OssClient::OSS_CALLBACK => $url);
             $this->putObjectCallbackOk($options, "200");
         } 
         // Unspecified typre 
        {
-            $json = 
+            $url = 
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}"
+                "callbackBody":"bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&imageInfo.height=${imageInfo.height}&imageInfo.width=${imageInfo.width}&imageInfo.format=${imageInfo.format}"
             }';
-            $options = array(OssClient::OSS_CALLBACK => $json);
+            $options = array(OssClient::OSS_CALLBACK => $url);
             $this->putObjectCallbackOk($options, "200");
         }
         //json and body is chinese
@@ -174,7 +176,7 @@ class CallbackTest extends TestOssClientBase
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
+                "callbackBody":"{\" 春水碧于天，画船听雨眠。\":\"垆边人似月，皓腕凝霜雪。\"}",
                 "callbackBodyType":"application/json"
             }';
             $options = array(OssClient::OSS_CALLBACK => $json);
@@ -182,14 +184,14 @@ class CallbackTest extends TestOssClientBase
         }
         //url and body is chinese
         {
-            $json = 
+            $url = 
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
                 "callbackBody":"春水碧于天，画船听雨眠。垆边人似月，皓腕凝霜雪",
                 "callbackBodyType":"application/x-www-form-urlencoded"
             }';
-            $options = array(OssClient::OSS_CALLBACK => $json);
+            $options = array(OssClient::OSS_CALLBACK => $url);
             $this->putObjectCallbackOk($options, "200");
         }
         //json and add callback_var
@@ -198,7 +200,7 @@ class CallbackTest extends TestOssClientBase
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size},\"x:var1\":${x:var1},\"x:var2\":${x:var2}}",
                 "callbackBodyType":"application/json"
             }';
             
@@ -214,11 +216,11 @@ class CallbackTest extends TestOssClientBase
         }
         //url and add callback_var
         {
-            $json = 
+            $url = 
             '{
                 "callbackUrl":"callback.oss-demo.com:23450",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBody":"bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&imageInfo.height=${imageInfo.height}&imageInfo.width=${imageInfo.width}&imageInfo.format=${imageInfo.format}&my_var1=${x:var1}&my_var2=${x:var2}",
                 "callbackBodyType":"application/x-www-form-urlencoded"
             }';
             $var = 
@@ -226,7 +228,7 @@ class CallbackTest extends TestOssClientBase
                 "x:var1":"value1凌波不过横塘路，但目送，芳",
                 "x:var2":"值2"
             }';
-            $options = array(OssClient::OSS_CALLBACK => $json,
+            $options = array(OssClient::OSS_CALLBACK => $url,
                              OssClient::OSS_CALLBACK_VAR => $var
                             );
             $this->putObjectCallbackOk($options, "200");
@@ -245,19 +247,19 @@ class CallbackTest extends TestOssClientBase
                 "callbackBodyType":"application/json"
             }';
             $options = array(OssClient::OSS_CALLBACK => $json);
-            $this->putObjectCallbackFailed($options, "");
+            $this->putObjectCallbackFailed($options, "203");
         }
 
         {
-            $json = 
+            $url = 
             '{
                 "callbackUrl":"http://www.baidu.com",
                 "callbackHost":"oss-cn-hangzhou.aliyuncs.com",
-                "callbackBody":"{\"mimeType\":${mimeType},\"size\":${size}}",
+                "callbackBody":"bucket=${bucket}&object=${object}&etag=${etag}&size=${size}&mimeType=${mimeType}&imageInfo.height=${imageInfo.height}&imageInfo.width=${imageInfo.width}&imageInfo.format=${imageInfo.format}&my_var1=${x:var1}&my_var2=${x:var2}",
                 "callbackBodyType":"application/x-www-form-urlencoded"
             }';      
-            $options = array(OssClient::OSS_CALLBACK => $json);
-            $this->putObjectCallbackFailed($options, "");
+            $options = array(OssClient::OSS_CALLBACK => $url);
+            $this->putObjectCallbackFailed($options, "203");
         }
 
     }
@@ -268,7 +270,7 @@ class CallbackTest extends TestOssClientBase
         $content = file_get_contents(__FILE__);
         try {
             $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
-            $this->assertEquals($status, $result['_info']['http_code']);
+            $this->assertEquals($status, $result['info']['http_code']);
             $this->assertEquals("{\"Status\":\"OK\"}", $result['body']);
         } catch (OssException $e) {
             $this->assertFalse(true);
@@ -283,6 +285,7 @@ class CallbackTest extends TestOssClientBase
             $result = $this->ossClient->putObject($this->bucket, $object, $content, $options);
             $this->assertTrue(false);
         } catch (OssException $e) {
+            $this->assertEquals($status, $e->getHTTPStatus());
             $this->assertTrue(true);
         }
     }

--- a/tests/OSS/Tests/ContentTypeTest.php
+++ b/tests/OSS/Tests/ContentTypeTest.php
@@ -4,9 +4,6 @@ namespace OSS\Tests;
 
 require_once __DIR__ . '/Common.php';
 
-use OSS\OssClient;
-use OSS\Core\OssException;
-
 class ContentTypeTest extends \PHPUnit_Framework_TestCase
 {
     private function runCmd($cmd)

--- a/tests/OSS/Tests/CopyObjectResult.php
+++ b/tests/OSS/Tests/CopyObjectResult.php
@@ -11,7 +11,7 @@ class CopyObjectResultTest extends \PHPUnit_Framework_TestCase
     private $body = <<<BBBB
 <?xml version="1.0" encoding="utf-8"?>
 <CopyObjectResult>
-  <LastModified>Fri, 24 Feb 2012 07:18:48 GM</LastModified>
+  <LastModified>Fri, 24 Feb 2012 07:18:48 GMT</LastModified>
   <ETag>"5B3C1A2E053D763E1B002CC607C5A0FE"</ETag>
 </CopyObjectResult>
 BBBB;
@@ -34,7 +34,7 @@ BBBB;
         $result = new CopyObjectResult($response);
         $data = $result->getData();
         $this->assertTrue($result->isOK());
-        $this->assertEquals("Fri, 24 Feb 2012 07:18:48 GM", $data[0]);
+        $this->assertEquals("Fri, 24 Feb 2012 07:18:48 GMT", $data[0]);
         $this->assertEquals("\"5B3C1A2E053D763E1B002CC607C5A0FE\"", $data[1]);
     }
 

--- a/tests/OSS/Tests/CopyObjectResult.php
+++ b/tests/OSS/Tests/CopyObjectResult.php
@@ -40,7 +40,7 @@ BBBB;
 
     public function testFailResponse()
     {
-        $response = new ResponseCore(array(), "", 301);
+        $response = new ResponseCore(array(), "", 404);
         try {
             new CopyObjectResult($response);
             $this->assertFalse(true);
@@ -49,13 +49,4 @@ BBBB;
         }
     }
 
-    public function setUp()
-    {
-
-    }
-
-    public function tearDown()
-    {
-
-    }
 }

--- a/tests/OSS/Tests/CopyObjectResult.php
+++ b/tests/OSS/Tests/CopyObjectResult.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace OSS\Tests;
+
+use OSS\Core\OssException;
+use OSS\Http\ResponseCore;
+use OSS\Result\CopyObjectResult;
+
+class CopyObjectResultTest extends \PHPUnit_Framework_TestCase
+{
+    private $body = <<<BBBB
+<?xml version="1.0" encoding="utf-8"?>
+<CopyObjectResult>
+  <LastModified>Fri, 24 Feb 2012 07:18:48 GM</LastModified>
+  <ETag>"5B3C1A2E053D763E1B002CC607C5A0FE"</ETag>
+</CopyObjectResult>
+BBBB;
+
+    public function testNullResponse()
+    {
+        $response = null;
+        try {
+            new CopyObjectResult($response);
+            $this->assertFalse(true);
+        } catch (OssException $e) {
+            $this->assertEquals('raw response is null', $e->getMessage());
+        }
+    }
+
+    public function testOkResponse()
+    {
+        $header= array();
+        $response = new ResponseCore($header, $this->body, 200);
+        $result = new CopyObjectResult($response);
+        $data = $result->getData();
+        $this->assertTrue($result->isOK());
+        $this->assertEquals("Fri, 24 Feb 2012 07:18:48 GM", $data[0]);
+        $this->assertEquals("\"5B3C1A2E053D763E1B002CC607C5A0FE\"", $data[1]);
+    }
+
+    public function testFailResponse()
+    {
+        $response = new ResponseCore(array(), "", 301);
+        try {
+            new CopyObjectResult($response);
+            $this->assertFalse(true);
+        } catch (OssException $e) {
+
+        }
+    }
+
+    public function setUp()
+    {
+
+    }
+
+    public function tearDown()
+    {
+
+    }
+}

--- a/tests/OSS/Tests/LiveChannelXmlTest.php
+++ b/tests/OSS/Tests/LiveChannelXmlTest.php
@@ -9,7 +9,6 @@ use OSS\Model\LiveChannelListInfo;
 use OSS\Model\LiveChannelConfig;
 use OSS\Model\GetLiveChannelStatus;
 use OSS\Model\GetLiveChannelHistory;
-use OSS\Core\OssException;
 
 class LiveChannelXmlTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OSS/Tests/ObjectAclTest.php
+++ b/tests/OSS/Tests/ObjectAclTest.php
@@ -4,9 +4,6 @@ namespace OSS\Tests;
 
 require_once __DIR__ . '/Common.php';
 
-use OSS\OssClient;
-use OSS\Core\OssException;
-
 class ObjectAclTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetSet()

--- a/tests/OSS/Tests/OssClientBucketCorsTest.php
+++ b/tests/OSS/Tests/OssClientBucketCorsTest.php
@@ -5,7 +5,6 @@ namespace OSS\Tests;
 use OSS\Core\OssException;
 use OSS\Model\CorsConfig;
 use OSS\Model\CorsRule;
-use OSS\Core\OssUtil;
 use OSS\OssClient;
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'TestOssClientBase.php';

--- a/tests/OSS/Tests/OssClientBucketTest.php
+++ b/tests/OSS/Tests/OssClientBucketTest.php
@@ -3,7 +3,6 @@
 namespace OSS\Tests;
 
 use OSS\Core\OssException;
-use OSS\Core\OssUtil;
 use OSS\OssClient;
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'TestOssClientBase.php';

--- a/tests/OSS/Tests/OssClientImageTest.php
+++ b/tests/OSS/Tests/OssClientImageTest.php
@@ -5,12 +5,6 @@ namespace OSS\Tests;
 require_once __DIR__ . '/Common.php';
 
 use OSS\OssClient;
-use OSS\Model\LiveChannelConfig;
-use OSS\Model\LiveChannelInfo;
-use OSS\Model\LiveChannelListInfo;
-use OSS\Core\OssException;
-
-
 
 class OssClinetImageTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OSS/Tests/OssClientObjectTest.php
+++ b/tests/OSS/Tests/OssClientObjectTest.php
@@ -158,8 +158,9 @@ class OssClientObjectTest extends TestOssClientBase
         $options = array();
         try {
             $result = $this->ossClient->copyObject($this->bucket, $object, $to_bucket, $to_object, $options);
-            $this->assertNotEquals('', $result[0]);
-            $this->assertNotEquals('', $result[1]);
+            $this->assertFalse(empty($result));
+            $this->assertEquals(strlen("2016-11-21T03:46:58.000Z"), strlen($result[0]));
+            $this->assertEquals(strlen("\"5B3C1A2E053D763E1B002CC607C5A0FE\""), strlen($result[1]));
         } catch (OssException $e) {
             $this->assertFalse(true);
             var_dump($e->getMessage());

--- a/tests/OSS/Tests/OssClientObjectTest.php
+++ b/tests/OSS/Tests/OssClientObjectTest.php
@@ -71,8 +71,9 @@ class OssClientObjectTest extends TestOssClientBase
         }
 
         try {
-            $this->ossClient->deleteObjects($this->bucket, "stringtype", $options);
+            $result = $this->ossClient->deleteObjects($this->bucket, "stringtype", $options);
             $this->assertFalse(true);
+            $this->assertEquals('stringtype', $result[0]);
         } catch (OssException $e) {
             $this->assertEquals('objects must be array', $e->getMessage());
         }
@@ -150,12 +151,14 @@ class OssClientObjectTest extends TestOssClientBase
         $to_object = $object . '.copy';
         $options = array();
         try {
-            $this->ossClient->copyObject($this->bucket, $object, $to_bucket, $to_object, $options);
+            $result = $this->ossClient->copyObject($this->bucket, $object, $to_bucket, $to_object, $options);
+            $this->assertNotEquals('', $result[0]);
+            $this->assertNotEquals('', $result[1]);
         } catch (OssException $e) {
             $this->assertFalse(true);
             var_dump($e->getMessage());
 
-        }
+        } 
 
         /**
          * 检查复制的是否相同
@@ -245,7 +248,11 @@ class OssClientObjectTest extends TestOssClientBase
         $list = array($object1, $object2);
         try {
             $this->assertTrue($this->ossClient->doesObjectExist($this->bucket, $object2));
-            $this->ossClient->deleteObjects($this->bucket, $list, array('quiet' => true));
+            
+            $result = $this->ossClient->deleteObjects($this->bucket, $list);
+            $this->assertEquals($list[1], $result[0]);
+            $this->assertEquals($list[0], $result[1]);
+            
             $this->ossClient->deleteObjects($this->bucket, $list, array('quiet' => 'true'));
             $this->assertFalse($this->ossClient->doesObjectExist($this->bucket, $object2));
         } catch (OssException $e) {

--- a/tests/OSS/Tests/OssClientObjectTest.php
+++ b/tests/OSS/Tests/OssClientObjectTest.php
@@ -69,11 +69,17 @@ class OssClientObjectTest extends TestOssClientBase
         } catch (OssException $e) {
             $this->assertFalse(true);
         }
+  
+        try {
+            $result = $this->ossClient->deleteObjects($this->bucket, "stringtype", $options);
+            $this->assertEquals('stringtype', $result[0]);
+        } catch (OssException $e) {
+            $this->assertEquals('objects must be array', $e->getMessage());
+        }
 
         try {
             $result = $this->ossClient->deleteObjects($this->bucket, "stringtype", $options);
             $this->assertFalse(true);
-            $this->assertEquals('stringtype', $result[0]);
         } catch (OssException $e) {
             $this->assertEquals('objects must be array', $e->getMessage());
         }
@@ -253,7 +259,8 @@ class OssClientObjectTest extends TestOssClientBase
             $this->assertEquals($list[1], $result[0]);
             $this->assertEquals($list[0], $result[1]);
             
-            $this->ossClient->deleteObjects($this->bucket, $list, array('quiet' => 'true'));
+            $result = $this->ossClient->deleteObjects($this->bucket, $list, array('quiet' => 'true'));
+            $this->assertEquals(array(), $result);
             $this->assertFalse($this->ossClient->doesObjectExist($this->bucket, $object2));
         } catch (OssException $e) {
             $this->assertFalse(true);

--- a/tests/OSS/Tests/PutSetDeleteResultTest.php
+++ b/tests/OSS/Tests/PutSetDeleteResultTest.php
@@ -26,7 +26,7 @@ class ResultTest extends \PHPUnit_Framework_TestCase
             'x-oss-request-id' => '582AA51E004C4550BD27E0E4',
             'etag' => '595FA1EA77945233921DF12427F9C7CE',
             'content-md5' => 'WV+h6neUUjOSHfEkJ/nHzg==',
-            '_info' => array(
+            'info' => array(
                 'http_code' => '200',
                 'method' => 'PUT'
             ),
@@ -39,8 +39,8 @@ class ResultTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('582AA51E004C4550BD27E0E4', $data['x-oss-request-id']);
         $this->assertEquals('595FA1EA77945233921DF12427F9C7CE', $data['etag']);
         $this->assertEquals('WV+h6neUUjOSHfEkJ/nHzg==', $data['content-md5']);
-        $this->assertEquals('200', $data['_info']['http_code']);
-        $this->assertEquals('PUT', $data['_info']['method']);
+        $this->assertEquals('200', $data['info']['http_code']);
+        $this->assertEquals('PUT', $data['info']['method']);
     }
 
     public function testFailResponse()

--- a/tests/OSS/Tests/PutSetDeleteResultTest.php
+++ b/tests/OSS/Tests/PutSetDeleteResultTest.php
@@ -22,11 +22,25 @@ class ResultTest extends \PHPUnit_Framework_TestCase
 
     public function testOkResponse()
     {
-        $response = new ResponseCore(array(), "", 200);
+        $header= array(
+            'x-oss-request-id' => '582AA51E004C4550BD27E0E4',
+            'etag' => '595FA1EA77945233921DF12427F9C7CE',
+            'content-md5' => 'WV+h6neUUjOSHfEkJ/nHzg==',
+            '_info' => array(
+                'http_code' => '200',
+                'method' => 'PUT'
+            ),
+        );
+        $response = new ResponseCore($header, "this is a mock body, just for test", 200);
         $result = new PutSetDeleteResult($response);
+        $data = $result->getData();
         $this->assertTrue($result->isOK());
-        $this->assertNull($result->getData());
-        $this->assertNotNull($result->getRawResponse());
+        $this->assertEquals("this is a mock body, just for test", $data['body']);
+        $this->assertEquals('582AA51E004C4550BD27E0E4', $data['x-oss-request-id']);
+        $this->assertEquals('595FA1EA77945233921DF12427F9C7CE', $data['etag']);
+        $this->assertEquals('WV+h6neUUjOSHfEkJ/nHzg==', $data['content-md5']);
+        $this->assertEquals('200', $data['_info']['http_code']);
+        $this->assertEquals('PUT', $data['_info']['method']);
     }
 
     public function testFailResponse()

--- a/tests/OSS/Tests/WebsiteConfigTest.php
+++ b/tests/OSS/Tests/WebsiteConfigTest.php
@@ -4,7 +4,6 @@ namespace OSS\Tests;
 
 
 use OSS\Model\WebsiteConfig;
-use OSS\Core\OssException;
 
 class WebsiteConfigTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
- 修复返回PutSetDeleteResult的接口实际return null的问题，如putObject、deleteObject、createBucket、copyObject、completeMultipartUpload等26个接口，详见[Issue26](https://github.com/aliyun/aliyun-oss-php-sdk/issues/26)
