### PR TITLE
添加putObjectPart方法，允许以内存数据作分块上传

### DIFF
--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -1382,6 +1382,35 @@ class OssClient
     }
 
     /**
+     * 分片上传的块上传接口，上传内存中的数据
+     *
+     * @param string $bucket Bucket名称
+     * @param string $object Object名称
+     * @param string $uploadId
+     * @param string $content 上传的内容
+     * @param array  $options Key-Value数组
+     *
+     * @return string eTag
+     * @throws OssException
+     */
+    public function putObjectPart($bucket, $object, $uploadId, $content, $options = null)
+    {
+        $this->precheckCommon($bucket, $object, $options);
+        $this->precheckParam($options, self::OSS_PART_NUM, __FUNCTION__);
+
+        $options[self::OSS_METHOD] = self::OSS_HTTP_PUT;
+        $options[self::OSS_BUCKET] = $bucket;
+        $options[self::OSS_OBJECT] = $object;
+        $options[self::OSS_UPLOAD_ID] = $uploadId;
+
+        $options[self::OSS_CONTENT] = $content;
+        $options[self::OSS_CONTENT_LENGTH] = strlen($content);
+        $response = $this->auth($options);
+        $result = new UploadPartResult($response);
+        return $result->getData();
+    }
+
+    /**
      * 获取已成功上传的part
      *
      * @param string $bucket Bucket名称


### PR DESCRIPTION
在调用`initiateMultipartUpload`取得`$uploadId`之后，此方法可以无需打开和seek定位文件，直接以内存中的变量作为分片上传，全部分片上传后调用`completeMultipartUpload`即可完成上传。

适用于分片数据来自非本地文件的情况，如打开的http网络资源，或者自定义的数据读取方法，由特定算法生成的数据输出等等。