### PR TITLE
修复大小写敏感服务器时，被README.MD误导的问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tips:
 
 | Class | Explanation |
 |:------------------|:------------------------------------|
-|OSS\OSSClient | OSS client class. An OSSClient instance can be used to call the interface.  |
+|OSS\OssClient | OSS client class. An OSSClient instance can be used to call the interface.  |
 |OSS\Core\OSSException |OSS Exception class . You only need to pay attention to this exception when you use the OSSClient. |
 
 ### Initialize an OSSClient


### PR DESCRIPTION
readme.md使用`OSS\OSSClient`，而实际文件名却为OssClient.
autoload psr4找不到这个文件会爆OSS/OSSClient不存在的错误.

