### PR TITLE
add option Cache-Control & Expires in OSS

### DIFF
--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -2137,6 +2137,15 @@ class OssClient
         if (!isset($headers[self::OSS_ACCEPT_ENCODING])) {
             $headers[self::OSS_ACCEPT_ENCODING] = '';
         }
+        
+//        for check from option['Cache-Control'] exists
+        if (isset($options[self::OSS_CACHE_CONTROL])) {
+            $headers[self::OSS_CACHE_CONTROL] = $options[self::OSS_CACHE_CONTROL];
+        }
+//        for check from option['Expires'] exists
+        if (isset($options[self::OSS_EXPIRES])) {
+            $headers[self::OSS_EXPIRES] = $options[self::OSS_EXPIRES];
+        }
 
         uksort($headers, 'strnatcasecmp');
 


### PR DESCRIPTION
Adds a option to the Cache-Control & Expires in OSS, to speed up image access using cache-control & expires in OSS Alicloud

In response to: [#123](https://github.com/aliyun/aliyun-oss-php-sdk/issues/107)