### PR TITLE
fix Expect: 100-continue

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -713,6 +713,8 @@ class RequestCore
                 $temp_headers[] = $k . ': ' . $v;
             }
 
+            // fix "Expect: 100-continue"
+            $temp_headers[] = 'Expect:';
             curl_setopt($curl_handle, CURLOPT_HTTPHEADER, $temp_headers);
         }
 


### PR DESCRIPTION
cURL obeys the RFCs as it should. Meaning that for a HTTP/1.1 backend if the POST size is above 1024 bytes.
cURL sends a 'Expect: 100-continue' header. The server acknowledges and sends back the '100' status code.
cURL then sends the request body. This is proper behavior. 
But that lead to some problem. 
It's better to disable it.