### PR TITLE
解决filesiz读取文件缓存导致单个队列程序中多次上传文件时第1个文件正常上传之后的文件全部都是0KB的BUG

### DIFF
--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -1164,6 +1164,7 @@ class OssClient
             throw new OssException($file . " file does not exist");
         }
         $options[self::OSS_FILE_UPLOAD] = $file;
+        clearstatcache();
         $file_size = filesize($options[self::OSS_FILE_UPLOAD]);
         $is_check_md5 = $this->isCheckMD5($options);
         if ($is_check_md5) {


### PR DESCRIPTION
我在队列中上传多个文件到阿里云OSS时第一个文件正常上传成功后，其他的文件上传至阿里云OSS全部都是0bk,经过检查是因为filesize() 函数缓存了文件状态，导致filesize()返回的文件大小不正确，清除一下文件状态的缓存就好了