### PR TITLE
Save CPU and memory usage

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -845,12 +845,10 @@ class RequestCore
             throw new RequestCore_Exception('cURL resource: ' . (string)$curl_handle . '; cURL error: ' . curl_error($curl_handle) . ' (' . curl_errno($curl_handle) . ')');
         }
 
-        $parsed_response = $this->process_response($curl_handle, $this->response);
-
         curl_close($curl_handle);
 
         if ($parse) {
-            return $parsed_response;
+            return $this->process_response($curl_handle, $this->response);
         }
 
         return $this->response;


### PR DESCRIPTION
the member function 'process_response' don't need call everytime.