### PR TITLE
compatible with PHP8

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        if ($curl_handle !== false) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
curl_init() now returns a CurlHandle object instead of Resource in PHP8.

CurlHandle is not a valid resource.