### PR TITLE
$requestUrl应当为局部变量

### DIFF
--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -2843,10 +2843,10 @@ class OssClient
             $non_signable_resource .= $conjunction . $query_string;
             $conjunction = '&';
         }
-        $this->requestUrl = $scheme . $hostname . $resource_uri . $signable_query_string . $non_signable_resource;
+        $requestUrl = $scheme . $hostname . $resource_uri . $signable_query_string . $non_signable_resource;
 
         //Creates the request
-        $request = new RequestCore($this->requestUrl, $this->requestProxy);
+        $request = new RequestCore($requestUrl, $this->requestProxy);
         $request->set_useragent($this->generateUserAgent());
         // Streaming uploads
         if (isset($options[self::OSS_FILE_UPLOAD])) {
@@ -2943,10 +2943,10 @@ class OssClient
         $request->add_header('Authorization', 'OSS ' . $this->accessKeyId . ':' . $signature);
 
         if (isset($options[self::OSS_PREAUTH]) && (integer)$options[self::OSS_PREAUTH] > 0) {
-            $signed_url = $this->requestUrl . $conjunction . self::OSS_URL_ACCESS_KEY_ID . '=' . rawurlencode($this->accessKeyId) . '&' . self::OSS_URL_EXPIRES . '=' . $options[self::OSS_PREAUTH] . '&' . self::OSS_URL_SIGNATURE . '=' . rawurlencode($signature);
+            $signed_url = $requestUrl . $conjunction . self::OSS_URL_ACCESS_KEY_ID . '=' . rawurlencode($this->accessKeyId) . '&' . self::OSS_URL_EXPIRES . '=' . $options[self::OSS_PREAUTH] . '&' . self::OSS_URL_SIGNATURE . '=' . rawurlencode($signature);
             return $signed_url;
         } elseif (isset($options[self::OSS_PREAUTH])) {
-            return $this->requestUrl;
+            return $requestUrl;
         }
 
         if ($this->timeout !== 0) {
@@ -2962,7 +2962,7 @@ class OssClient
             throw(new OssException('RequestCoreException: ' . $e->getMessage()));
         }
         $response_header = $request->get_response_header();
-        $response_header['oss-request-url'] = $this->requestUrl;
+        $response_header['oss-request-url'] = $requestUrl;
         $response_header['oss-redirects'] = $this->redirects;
         $response_header['oss-stringtosign'] = $string_to_sign;
         $response_header['oss-requestheaders'] = $request->request_headers;
@@ -3517,7 +3517,6 @@ class OssClient
 
     // user's domain type. It could be one of the four: OSS_HOST_TYPE_NORMAL, OSS_HOST_TYPE_IP, OSS_HOST_TYPE_SPECIAL, OSS_HOST_TYPE_CNAME
     private $hostType = self::OSS_HOST_TYPE_NORMAL;
-    private $requestUrl;
     private $requestProxy = null;
     private $accessKeyId;
     private $accessKeySecret;


### PR DESCRIPTION
$requestUrl声明为对象属性在协程环境中会导出现使用过程中数据被污染的情况，且在实际使用过程中，这一变量也只在这一方法局部使用，建议改为局部变量来避免该问题