### PR TITLE
Compatible with PHP8（curl_init return CurlHandle)

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -777,7 +777,7 @@ class RequestCore
      * data stored in the `curl_handle` and `response` properties unless replacement data is passed in via
      * parameters.
      *
-     * @param resource $curl_handle (Optional) The reference to the already executed cURL request.
+     * @param resource|\CurlHandle|null|false $curl_handle (Optional) The reference to the already executed cURL request. Receive CurlHandle instance from PHP8.0
      * @param string $response (Optional) The actual response content itself that needs to be parsed.
      * @return ResponseCore A <ResponseCore> object containing a parsed HTTP response.
      */
@@ -788,8 +788,8 @@ class RequestCore
             $this->response = $response;
         }
 
-        // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        // As long as this came back as a valid resource or CurlHandle instance...
+        if (is_resource($curl_handle) || (is_object($curl_handle) && get_class($curl_handle) === 'CurlHandle')) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
fix #154   兼容PHP8.0。完善process_response方法的PHP-Doc.

理论上process_response只应该接收resource|\CurlHandle|false三种参数类型，但是tests/OSS/Tests/HttpTest.php文件里有一处方法调用的实参写了null，为了兼容，所以在PHP-Doc中也加入了null类型。