### PR TITLE
Support PHP 8

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        if (is_resource($curl_handle) || $curl_handle instanceof \CurlHandle) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
PHP 8 curl extension, curl_init() returns CurlHandle instead of resource.

https://www.php.net/manual/en/class.curlhandle.php

