### PR TITLE
Compatibility issues with PHP 5.4

### DIFF
--- a/src/OSS/Core/OssUtil.php
+++ b/src/OSS/Core/OssUtil.php
@@ -439,7 +439,8 @@ BBB;
             $sub_object = $xml->addChild('Object');
             $key = OssUtil::sReplace($object->getKey());
             $sub_object->addChild('Key', $key);
-            if (!empty($object->getVersionId())) {
+            $versionId = $object->getVersionId();
+            if (!empty($versionId)) {
                 $sub_object->addChild('VersionId', $object->getVersionId());
             }
         }


### PR DESCRIPTION
PHP Fatal error:  Can't use method return value in write context in OssUtil.php on line 442