### PR TITLE
支持Swoole的cURL handle

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        if (is_resource($curl_handle) || ($curl_handle instanceof \Swoole\Curl\Handler)) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
支持Swoole的cURL handle，运行测试环境：

$php --version
PHP 7.4.14 (cli) (built: Mar 23 2021 11:21:02) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies

$php --ri swoole

swoole

Swoole => enabled
Author => Swoole Team team@swoole.com
Version => 4.6.2
Built => Mar 23 2021 16:33:39
coroutine => enabled with boost asm context
kqueue => enabled
rwlock => enabled
openssl => OpenSSL 1.1.1j 16 Feb 2021
dtls => enabled
http2 => enabled
pcre => enabled
zlib => 1.2.11
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 262144 => 262144