### PR TITLE
fix: php8 curl_init return a CurlHandle object which cause check error

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        if (is_resource($curl_handle) || is_object($curl_handle)) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
PHP8 return a `CurlHandle` instance instead of `resource` type which cause check error