### PR TITLE
Update RequestCore.php

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource...
-        if (is_resource($curl_handle)) {
+        if ((PHP_MAJOR_VERSION >= 8 && $curl_handle !== false) || is_resource($curl_handle)) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
upon to php 8.0, curl_init always return a CurlHandle instance on success or false, previously a resource was returned.