### PR TITLE
兼容swoole的cURL handle

### DIFF
--- a/src/OSS/Http/RequestCore.php
+++ b/src/OSS/Http/RequestCore.php
@@ -789,7 +789,7 @@ class RequestCore
         }
 
         // As long as this came back as a valid resource or CurlHandle instance...
-        if (is_resource($curl_handle) || (is_object($curl_handle) && get_class($curl_handle) === 'CurlHandle')) {
+        if (is_resource($curl_handle) || (is_object($curl_handle) && in_array(get_class($curl_handle), ['CurlHandle', 'Swoole\Coroutine\Curl\Handle']))) {
             // Determine what's what.
             $header_size = curl_getinfo($curl_handle, CURLINFO_HEADER_SIZE);
             $this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
目前swoole curl handle 没有兼容
swoole 环境
swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 4.8.1
Built => Nov 10 2021 14:57:16
coroutine => enabled with boost asm context
epoll => enabled
eventfd => enabled
signalfd => enabled
cpu_affinity => enabled
spinlock => enabled
rwlock => enabled
sockets => enabled
openssl => OpenSSL 1.1.1f  31 Mar 2020
dtls => enabled
http2 => enabled
json => enabled
curl-native => enabled
pcre => enabled
mutex_timedlock => enabled
pthread_barrier => enabled
futex => enabled
mysqlnd => enabled
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => Off => Off
swoole.unixsock_buffer_size => 8388608 => 8388608