### PR TITLE
Update OssClient.php

### DIFF
--- a/src/OSS/OssClient.php
+++ b/src/OSS/OssClient.php
@@ -3442,7 +3442,7 @@ class OssClient
             return $string_to_sign;
 
         $queryStringParams = explode('&', $explodeResult[$index - 1]);
-        sort($queryStringParams);
+        sort($queryStringParams, SORT_NUMERIC);
 
         foreach($queryStringParams as $params)
         {


### PR DESCRIPTION
对要签名的字符串进行排序,当出现"-"时(例如:callback-var),会出现排序不正确的情况,最终导致签名错误.